### PR TITLE
only parse ms if it's a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ var co = require('co');
 
 module.exports = function(ms, fn){
   var fn = isGenerator(fn) ? co(fn) : fn;
-  var ms = parse(ms);
+  if (typeof ms === 'string')
+    ms = parse(ms);
 
   return function(done){
     var ended;


### PR DESCRIPTION
Currently, if you call `timeout` with a numeric value, you can incorrect behavior:

``` javascript
function *task() { ... }

var result = timeout(1000, task);
// times out after 1 millisecond
```

This is because calling `ms()` with a number returns the string version, and `ms(1000) == '1s'`, which when passed to `setTimeout` just gets parsed which returns `1`.
